### PR TITLE
:construction_worker: Add conan version input parameter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
       repo:
         required: true
         type: string
+      conan_version:
+        required: true
+        type: string
 
 jobs:
   find_directory:
@@ -43,7 +46,7 @@ jobs:
           repository: ${{ inputs.repo }}
 
       - name: 📥 Install CMake + Conan
-        run: pip3 install --upgrade cmake conan
+        run: pip3 install cmake conan==${{ inputs.conan_version }}
 
       - name: 📡 Add `libhal-trunk` conan remote
         run: conan remote add libhal-trunk

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ on:
       repo:
         required: true
         type: string
+      conan_version:
+        required: true
+        type: string
 
 jobs:
   deploy:
@@ -21,7 +24,7 @@ jobs:
           submodules: true
 
       - name: 📥 Install CMake & Conan
-        run: pip install cmake conan==2.0.0
+        run: pip3 install cmake conan==${{ inputs.conan_version }}
 
       - name: 📡 Add `libhal-trunk` conan remote
         run: |

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -28,6 +28,9 @@ on:
       repo:
         type: string
         default: ${{ github.repository }}
+      conan_version:
+        type: string
+        default: "2.0.1"
 
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -45,6 +48,7 @@ jobs:
       coverage: ${{ inputs.coverage }}
       fail_on_coverage: ${{ inputs.fail_on_coverage }}
       coverage_threshold: ${{ inputs.coverage_threshold }}
+      conan_version: ${{ inputs.conan_version }}
     secrets: inherit
 
   build:
@@ -52,6 +56,7 @@ jobs:
     with:
       app_folder: ${{ inputs.app_folder }}
       repo: ${{ inputs.repo }}
+      conan_version: ${{ inputs.conan_version }}
     secrets: inherit
 
   lint:
@@ -85,4 +90,5 @@ jobs:
     with:
       library: ${{ inputs.library }}
       repo: ${{ inputs.repo }}
+      conan_version: ${{ inputs.conan_version }}
     secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ on:
       repo:
         required: true
         type: string
+      conan_version:
+        required: true
+        type: string
 
 jobs:
   run_tests:
@@ -57,7 +60,7 @@ jobs:
         run: ${{ matrix.installations }}
 
       - name: 📥 Install CMake + Conan
-        run: pip3 install --upgrade cmake conan==2.0.0
+        run: pip3 install cmake conan==${{ inputs.conan_version }}
 
       - name: 📡 Add `libhal-trunk` conan remote
         run: conan remote add libhal-trunk
@@ -74,7 +77,7 @@ jobs:
 
       - name: 📥 Install GCovr
         if: ${{ matrix.enable_coverage }}
-        run: pip3 install --upgrade gcovr
+        run: pip3 install gcovr
 
       - name: 🔎 Generate Code Coverage
         if: ${{ matrix.enable_coverage }}


### PR DESCRIPTION
This will allow the libhal/ci to be able to control the exact version of conan it uses for libhal ci projects and users.