### PR TITLE
:construction_worker: Set default for library name

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
     inputs:
       library:
-        required: true
+        default: ${{ github.event.repository.name }}
         type: string
       coverage:
         default: true


### PR DESCRIPTION
Library name is set to the name of the repo but can be overwritten.