### PR TITLE
👷🏾  Use `conan build` for package testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: 📡 Add `libhal-trunk` conan remote
         run: conan remote add libhal-trunk
-             https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
+          https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
 
       - name: 📡 Create and setup default profile
         run: conan profile detect --force
@@ -74,7 +74,7 @@ jobs:
 
       - name: 📦 Generate Package & Install Library (if possible)
         continue-on-error: true
-        run: conan create . --build=missing -s compiler.version=11 -s compiler.cppstd=20 -s compiler=gcc -s compiler.libcxx=libstdc++ -s:b compiler.cppstd=20 -s:b compiler=gcc -s:b compiler.version=11 -s:b compiler.libcxx=libstdc++ -c tools.build:skip_test=True
+        run: conan create . --build=missing -s compiler.version=11 -s compiler.cppstd=20 -s compiler=gcc -s compiler.libcxx=libstdc++ -s:b compiler.cppstd=20 -s:b compiler=gcc -s:b compiler.version=11 -s:b compiler.libcxx=libstdc++
 
       - name: 🏗️ Build
         working-directory: ${{ inputs.app_folder }}

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -28,10 +28,10 @@ on:
         default: false
         type: boolean
       coverage_threshold:
-        default: '40 80'
+        default: "40 80"
         type: string
       source_dir:
-        default: 'include/'
+        default: "include/"
         type: string
       skip_deploy:
         default: false
@@ -44,8 +44,7 @@ on:
         default: ${{ github.repository }}
       conan_version:
         type: string
-        default: "2.0.1"
-
+        default: "2.0.6"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -90,7 +89,7 @@ jobs:
     secrets: inherit
 
   publish_artifacts:
-    needs: [ lint, docs, tests, build ]
+    needs: [lint, docs, tests, build]
     uses: ./.github/workflows/publish.yml
     with:
       library: ${{ inputs.library }}
@@ -98,7 +97,7 @@ jobs:
     secrets: inherit
 
   deploy_package:
-    needs: [ lint, docs, tests, build ]
+    needs: [lint, docs, tests, build]
     if: ${{ !inputs.skip_deploy }}
     uses: ./.github/workflows/deploy.yml
     with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: 📡 Add `libhal-trunk` conan remote
         run: conan remote add libhal-trunk
-             https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
+          https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
 
       - name: 📡 Create and setup default profile
         run: conan profile detect --force
@@ -87,7 +87,7 @@ jobs:
         run: conan profile show
 
       - name: 🔬 Build & Run Unit Tests
-        run: conan create . --build=missing -s compiler.cppstd=20 -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.standard_library }} -s compiler=${{ matrix.toolchain }} -s build_type=Debug -c tools.build:skip_test=True -tf tests
+        run: conan build . --build=missing -s compiler.cppstd=20 -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.standard_library }} -s compiler=${{ matrix.toolchain }} -s build_type=Debug
 
       - name: 📥 Install GCovr
         if: ${{ matrix.enable_coverage }}
@@ -95,15 +95,15 @@ jobs:
 
       - name: 🔎 Generate Code Coverage
         if: ${{ matrix.enable_coverage }}
-        working-directory: tests/build
+        working-directory: build
         run: |
-             mkdir coverage/ && python3 -m gcovr --root ../../ --exclude ".*/third_party/.*" --cobertura coverage/coverage.xml --html coverage/index.html --html-details --sort-percentage
+          mkdir coverage/ && python3 -m gcovr --root ../../ --exclude ".*/third_party/.*" --cobertura coverage/coverage.xml --html coverage/index.html --html-details --sort-percentage
 
       - name: Coverage Summary
         if: ${{ matrix.enable_coverage }}
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          filename: tests/build/coverage/coverage.xml
+          filename: build/coverage/coverage.xml
           badge: true
           fail_below_min: ${{ inputs.fail_on_coverage }}
           format: markdown
@@ -116,13 +116,13 @@ jobs:
       - name: Extract & Save Coverage SVG
         if: ${{ matrix.enable_coverage }}
         run: wget
-             $(cat code-coverage-results.md |
-               grep -Eo 'https://img.shields.io/badge/[^)]*')
-              -O tests/build/coverage/coverage.svg
+          $(cat code-coverage-results.md |
+          grep -Eo 'https://img.shields.io/badge/[^)]*')
+          -O build/coverage/coverage.svg
 
       - uses: actions/upload-artifact@v3
         if: ${{ matrix.enable_coverage }}
         with:
           name: coverage
           retention-days: 1
-          path: tests/build/coverage/
+          path: build/coverage/


### PR DESCRIPTION
Conan folks have stated that testing should be apart of building and
that using conan create and directing the `test_package` to the `test/`
directory is bad form. This added additional complexity and confusing
arguments to command in that it disabled tests and yet it was the
tests.yml.

Instead this change uses `conan build` to build the package and store
the results in a `build/` directory at the package's root. This makes
the process much more clear, conforming to the conan best practices and
simpler to understand for readers.

- Format a few of the .yml files
- Remove "test disable" from build