### PR TITLE
:sparkles: Add device_deploy.yml

### DIFF
--- a/.github/workflows/device_deploy.yml
+++ b/.github/workflows/device_deploy.yml
@@ -1,0 +1,76 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Device 🏗️ Build 🚀 Deploy
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      library:
+        default: ${{ github.event.repository.name }}
+        type: string
+      repo:
+        type: string
+        default: ${{ github.repository }}
+      conan_version:
+        type: string
+        default: "2.0.6"
+
+jobs:
+  cortex-m0:
+    uses: ./.github/workflows/device_deploy_unit.yml
+    with:
+      library: ${{ inputs.library }}
+      repo: ${{ inputs.repo }}
+      conan_version: ${{ inputs.conan_version }}
+      profile: cortex-m0
+      profile_source: https://github.com/libhal/libhal-armcortex.git
+    secrets: inherit
+  cortex-m1:
+    uses: ./.github/workflows/device_deploy_unit.yml
+    with:
+      library: ${{ inputs.library }}
+      repo: ${{ inputs.repo }}
+      conan_version: ${{ inputs.conan_version }}
+      profile: cortex-m1
+      profile_source: https://github.com/libhal/libhal-armcortex.git
+    secrets: inherit
+  cortex-m3:
+    uses: ./.github/workflows/device_deploy_unit.yml
+    with:
+      library: ${{ inputs.library }}
+      repo: ${{ inputs.repo }}
+      conan_version: ${{ inputs.conan_version }}
+      profile: cortex-m3
+      profile_source: https://github.com/libhal/libhal-armcortex.git
+    secrets: inherit
+  cortex-m4:
+    uses: ./.github/workflows/device_deploy_unit.yml
+    with:
+      library: ${{ inputs.library }}
+      repo: ${{ inputs.repo }}
+      conan_version: ${{ inputs.conan_version }}
+      profile: cortex-m4
+      profile_source: https://github.com/libhal/libhal-armcortex.git
+    secrets: inherit
+  cortex-m4f:
+    uses: ./.github/workflows/device_deploy_unit.yml
+    with:
+      library: ${{ inputs.library }}
+      repo: ${{ inputs.repo }}
+      conan_version: ${{ inputs.conan_version }}
+      profile: cortex-m4f
+      profile_source: https://github.com/libhal/libhal-armcortex.git
+    secrets: inherit

--- a/.github/workflows/device_deploy_unit.yml
+++ b/.github/workflows/device_deploy_unit.yml
@@ -1,0 +1,99 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Device 🏗️ Build 🚀 Deploy
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      library:
+        default: ${{ github.event.repository.name }}
+        type: string
+      repo:
+        type: string
+        default: ${{ github.repository }}
+      conan_version:
+        type: string
+        default: "2.0.6"
+      profile:
+        required: true
+        type: string
+      profile_source:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          repository: ${{ inputs.repo }}
+
+      - name: 📥 Install CMake + Conan
+        run: pip3 install cmake conan==${{ inputs.conan_version }}
+
+      - name: 📡 Add `libhal-trunk` conan remote
+        run: conan remote add libhal-trunk
+          https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
+
+      - name: 📡 Create and setup default profile
+        run: conan profile detect --force
+
+      - name: 👁️‍🗨️ Show conan profile
+        run: conan profile show
+
+      - name: 📡 Install linux default profiles
+        run: conan config install -sf profiles/x86_64/linux/ -tf profiles https://github.com/libhal/conan-config.git
+
+      - name: 📡 Sign into JFrog Artifactory
+        if: ${{ github.ref == 'refs/heads/main' }}
+        env:
+          API_KEY: ${{ secrets.JFROG_LIBHAL_TRUNK_API_KEY }}
+          JFROG_USER: ${{ secrets.JFROG_LIBHAL_TRUNK_USER }}
+        run: conan remote login -p $API_KEY libhal-trunk $JFROG_USER
+
+      - name: Install libhal settings_user.yml
+        run: conan config install -sf profiles/baremetal https://github.com/libhal/conan-config.git
+
+      - name: Install profiles processor profiles
+        run: conan config install -tf profiles -sf conan/profiles/ ${{ inputs.profile_source }}
+
+      - name: 📦 Create `Debug` package for ${{ inputs.profile }}
+        run: conan create . -pr ${{ inputs.profile }} -s build_type=Debug -b missing
+
+      - name: 📦 Create `RelWithDebInfo` package for ${{ inputs.profile }}
+        run: conan create . -pr ${{ inputs.profile }} -s build_type=RelWithDebInfo -b missing
+
+      - name: 📦 Create `MinSizeRel` package for ${{ inputs.profile }}
+        run: conan create . -pr ${{ inputs.profile }} -s build_type=MinSizeRel -b missing
+
+      - name: 📦 Create `Release` package for ${{ inputs.profile }}
+        run: conan create . -pr ${{ inputs.profile }} -s build_type=Release -b missing
+
+      - name: Check file existence
+        id: demos_found
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "demos"
+
+      - name: 🏗️ Build demos for ${{ inputs.profile }}
+        if: steps.demos_found.outputs.files_exists == 'true'
+        run: conan build demos -pr ${{ inputs.profile }} -s build_type=MinSizeRel -b missing
+
+      - name: 🆙 Upload package to `libhal-trunk` repo
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: conan upload "${{ inputs.library }}/*" --confirm -r=libhal-trunk

--- a/.github/workflows/self_check.yml
+++ b/.github/workflows/self_check.yml
@@ -77,3 +77,10 @@ jobs:
       repo: libhal/libhal-armcortex
       profile: cortex-m0
     secrets: inherit
+
+  libhal-soft:
+    uses: ./.github/workflows/device_deploy.yml
+    with:
+      library: libhal-soft
+      repo: libhal/libhal-soft
+    secrets: inherit


### PR DESCRIPTION
This ci target is used by libhal device driver libraries to cross compile binaries for every supported microcontroller in libhal.