### PR TITLE
:green_heart: Add support for prereleases `-` in badges

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           path: docs/coverage
 
       - name: Generate Latest Version Badge
-        run: wget "https://img.shields.io/badge/Latest%20Version-$(conan inspect . | grep version | cut -c 10- )-green" -O docs/latest_version.svg
+        run: wget "https://img.shields.io/badge/Latest%20Version-$(conan inspect . | grep version | cut -c 10- | sed s/-/~/ )-green" -O docs/latest_version.svg
 
       - name: Setup Pages
         uses: actions/configure-pages@v2
@@ -60,7 +60,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: 'docs/'
+          path: "docs/"
 
       - name: 🚀 Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Replace `-` with `~` in version number in badge to allow shield.io URL parsing to work.