### PR TITLE
:construction_worker: Make uploads to artifactory require tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,8 @@ jobs:
       - name: 📥 Install CMake + Conan
         run: pip3 install cmake conan==${{ inputs.conan_version }}
 
-      - name: 📡 Add `libhal-trunk` conan remote
-        run: conan remote add libhal-trunk
+      - name: 📡 Add `libhal` repo to conan remotes
+        run: conan remote add libhal
           https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
 
       - name: 📡 Create and setup default profile

--- a/.github/workflows/demo_builder.yml
+++ b/.github/workflows/demo_builder.yml
@@ -49,8 +49,8 @@ jobs:
       - name: 📥 Install CMake + Conan
         run: pip3 install cmake conan==${{ inputs.conan_version }}
 
-      - name: 📡 Add `libhal-trunk` conan remote
-        run: conan remote add libhal-trunk
+      - name: 📡 Add `libhal` repo to conan remotes
+        run: conan remote add libhal
           https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
 
       - name: 📡 Create and setup default profile
@@ -64,7 +64,7 @@ jobs:
         env:
           API_KEY: ${{ secrets.JFROG_LIBHAL_TRUNK_API_KEY }}
           JFROG_USER: ${{ secrets.JFROG_LIBHAL_TRUNK_USER }}
-        run: conan remote login -p $API_KEY libhal-trunk $JFROG_USER
+        run: conan remote login -p $API_KEY libhal $JFROG_USER
 
       - name: Install libhal settings_user.yml
         run: conan config install -sf profiles/baremetal https://github.com/libhal/conan-config.git

--- a/.github/workflows/deploy_unit.yml
+++ b/.github/workflows/deploy_unit.yml
@@ -46,8 +46,8 @@ jobs:
       - name: 📥 Install CMake + Conan
         run: pip3 install cmake conan==${{ inputs.conan_version }}
 
-      - name: 📡 Add `libhal-trunk` conan remote
-        run: conan remote add libhal-trunk
+      - name: 📡 Add `libhal` repo to conan remotes
+        run: conan remote add libhal
           https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
 
       - name: 📡 Create and setup default profile
@@ -64,7 +64,7 @@ jobs:
         env:
           API_KEY: ${{ secrets.JFROG_LIBHAL_TRUNK_API_KEY }}
           JFROG_USER: ${{ secrets.JFROG_LIBHAL_TRUNK_USER }}
-        run: conan remote login -p $API_KEY libhal-trunk $JFROG_USER
+        run: conan remote login -p $API_KEY libhal $JFROG_USER
 
       - name: Install libhal settings_user.yml
         run: conan config install -sf profiles/baremetal https://github.com/libhal/conan-config.git
@@ -87,6 +87,6 @@ jobs:
       - name: 📦 Create `Release` package for ${{ inputs.profile }}
         run: conan create . -pr ${{ inputs.profile }} -s build_type=Release -b missing
 
-      - name: 🆙 Upload package to `libhal-trunk` repo
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: conan upload "${{ inputs.library }}/*" --confirm -r=libhal-trunk
+      - name: 🆙 Upload package version ${{ github.ref_name }} to `libhal` repo
+        if: startsWith(github.ref, 'refs/tags/')
+        run: conan upload "${{ inputs.library }}/${{ github.ref_name }}" --confirm -r=libhal

--- a/.github/workflows/platform_deploy.yml
+++ b/.github/workflows/platform_deploy.yml
@@ -49,8 +49,8 @@ jobs:
       - name: 📥 Install CMake + Conan
         run: pip3 install cmake conan==${{ inputs.conan_version }}
 
-      - name: 📡 Add `libhal-trunk` conan remote
-        run: conan remote add libhal-trunk
+      - name: 📡 Add `libhal` repo to conan remotes
+        run: conan remote add libhal
           https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
 
       - name: 📡 Create and setup default profile
@@ -64,7 +64,7 @@ jobs:
         env:
           API_KEY: ${{ secrets.JFROG_LIBHAL_TRUNK_API_KEY }}
           JFROG_USER: ${{ secrets.JFROG_LIBHAL_TRUNK_USER }}
-        run: conan remote login -p $API_KEY libhal-trunk $JFROG_USER
+        run: conan remote login -p $API_KEY libhal $JFROG_USER
 
       - name: Install libhal settings_user.yml
         run: conan config install -sf profiles/baremetal https://github.com/libhal/conan-config.git
@@ -94,6 +94,6 @@ jobs:
       - name: 🏗️ Build demos for ${{ inputs.profile }}
         run: conan build demos -pr ${{ inputs.profile }} -s build_type=MinSizeRel
 
-      - name: 🆙 Upload package to `libhal-trunk` repo
-        if: github.ref == 'refs/heads/main' && inputs.upload
-        run: conan upload "${{ inputs.library }}/*" --confirm -r=libhal-trunk
+      - name: 🆙 Upload package to `libhal` repo
+        if: startsWith(github.ref, 'refs/tags/') && inputs.upload
+        run: conan upload "${{ inputs.library }}/*" --confirm -r=libhal

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,12 @@ jobs:
         with:
           path: "docs/"
 
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+
       - name: 🚀 Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,8 +72,8 @@ jobs:
       - name: 📥 Install CMake + Conan
         run: pip3 install cmake conan==${{ inputs.conan_version }}
 
-      - name: 📡 Add `libhal-trunk` conan remote
-        run: conan remote add libhal-trunk
+      - name: 📡 Add `libhal` repo to conan remotes
+        run: conan remote add libhal
           https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
 
       - name: 📡 Create and setup default profile
@@ -130,12 +130,12 @@ jobs:
           path: build/coverage/
 
       - name: 📡 Sign into JFrog Artifactory
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           API_KEY: ${{ secrets.JFROG_LIBHAL_TRUNK_API_KEY }}
           JFROG_USER: ${{ secrets.JFROG_LIBHAL_TRUNK_USER }}
-        run: conan remote login -p $API_KEY libhal-trunk $JFROG_USER
+        run: conan remote login -p $API_KEY libhal $JFROG_USER
 
-      - name: 🆙 Upload package to `libhal-trunk` repo
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: conan upload "${{ inputs.library }}/*" --confirm -r=libhal-trunk
+      - name: 🆙 Upload package to `libhal` repo
+        if: startsWith(github.ref, 'refs/tags/')
+        run: conan upload "${{ inputs.library }}/${{ github.ref_name }}" --confirm -r=libhal


### PR DESCRIPTION
Rather than always attempting to upload to the artifactory, use tag pushes to:

1. Automatically create a new release for the repo with auto generated release text
2. Upload packages to the package repo

If the tag number does not match the version of the package, uploads and CI fail, which is the expected and desired behavior.

Do some slight renaming for the fields.

This will be released in version 4.0.0