### PR TITLE
:construction_worker: Remove releases from CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,20 +65,3 @@ jobs:
       - name: 🚀 Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
-
-  release:
-    if: startsWith(github.ref, 'refs/tags/') && github.repository == inputs.repo
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-          repository: ${{ inputs.repo }}
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          generate_release_notes: true


### PR DESCRIPTION
Doesn't seem to work with workflow_dispatch