### PR TITLE
🐛 Fix clang-tidy symbolic link

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
             compiler_version: 14
             os: macos-12
             standard_library: libc++
-            installations: brew install llvm && sudo ln -s /opt/homebrew/opt/llvm/bin/clang-tidy /usr/local/bin/clang-tidy
+            installations: brew install llvm && sudo ln -s $(brew --prefix llvm)/bin/clang-tidy /usr/local/bin/
             profile_path: profiles/x86_64/mac/
 
           # - toolchain: gcc


### PR DESCRIPTION
Use `$(brew --prefix llvm)` rather than hard coding the directory which
may change depending on the system it is installed on.