### PR TITLE
:adhesive_bandage: Run local conan build when coverage is enabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,8 @@ jobs:
       - name: 🔬 Create & Run Unit Tests
         run: conan create . --build=missing -s compiler.cppstd=20 -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.standard_library }} -s compiler=${{ matrix.toolchain }} -s build_type=Debug
 
-      - name: 🔬 Build & Run Unit Tests
+      - name: 🔬 Build & Run Unit Tests (for coverage)
+        if: ${{ matrix.enable_coverage }}
         run: conan build . --build=missing -s compiler.cppstd=20 -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.standard_library }} -s compiler=${{ matrix.toolchain }} -s build_type=Debug
 
       - name: 📥 Install GCovr


### PR DESCRIPTION
This disables running the `conan build .` step for tests if that workflow won't be used for generating coverage.