### PR TITLE
:green_heart: Revert to 2.0.6

### DIFF
--- a/.github/workflows/demo_builder.yml
+++ b/.github/workflows/demo_builder.yml
@@ -26,7 +26,7 @@ on:
         default: ${{ github.repository }}
       conan_version:
         type: string
-        default: "2.0.13"
+        default: "2.0.6"
       profile:
         type: string
         required: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ on:
         default: ${{ github.repository }}
       conan_version:
         type: string
-        default: "2.0.13"
+        default: "2.0.6"
 
 jobs:
   cortex-m0:

--- a/.github/workflows/deploy_unit.yml
+++ b/.github/workflows/deploy_unit.yml
@@ -26,7 +26,7 @@ on:
         default: ${{ github.repository }}
       conan_version:
         type: string
-        default: "2.0.13"
+        default: "2.0.6"
       profile:
         required: true
         type: string

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -38,7 +38,7 @@ on:
         default: ${{ github.repository }}
       conan_version:
         type: string
-        default: "2.0.13"
+        default: "2.0.6"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/platform_deploy.yml
+++ b/.github/workflows/platform_deploy.yml
@@ -26,7 +26,7 @@ on:
         default: ${{ github.repository }}
       conan_version:
         type: string
-        default: "2.0.13"
+        default: "2.0.6"
       profile:
         type: string
         required: true

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Inputs:
 - `repo`: The GitHub repository where the library is located. Default is the
   repository where the workflow is running.
 - `conan_version`: The version of Conan to use for building the library. Default
-  is "2.0.13".
+  is "2.0.6".
 
 This workflow is designed to be used in any GitHub Actions workflow by
 referencing it with the `uses` keyword and providing the necessary inputs. If an
@@ -228,7 +228,7 @@ Inputs:
 - `repo`: The GitHub repository where the library is located. Default is the
   repository where the workflow is running.
 - `conan_version`: The version of Conan to use for building the library. Default
-  is "2.0.13".
+  is "2.0.6".
 
 This workflow creates a job for each supported device and architecture. Each job
 uses the `deploy_unit.yml` workflow to build a package for the specified device
@@ -253,7 +253,7 @@ Inputs:
 - `repo`: The GitHub repository where the library is located. Default is the
   repository where the workflow is running.
 - `conan_version`: The version of Conan to use for building the library. Default
-  is "2.0.13".
+  is "2.0.6".
 - `profile`: The profile to use for building the package. This input is
   required.
 - `upload`: A boolean value indicating whether to upload the built package to
@@ -289,7 +289,7 @@ Inputs:
 - `repo`: The GitHub repository where the library is located. Default is the
   repository where the workflow is running.
 - `conan_version`: The version of Conan to use for building the library. Default
-  is "2.0.13".
+  is "2.0.6".
 - `profile`: The profile to use for building the demo. This input is required.
 - `processor_profile`: The URL of the processor profile to use for building the
   demo. Default is an empty string.


### PR DESCRIPTION
It seems that boost-leaf resolves to boost now with 2.0.13. It is marked as deprecated in the conan-center-index but that should merely warn the user to not use the library and to prefer boost itself. The root cause of the breakage is still unknown.